### PR TITLE
Export client types and `CustomFile`

### DIFF
--- a/src/client/mod.ts
+++ b/src/client/mod.ts
@@ -28,3 +28,5 @@ export * as tgClient from "./abstract_telegram_client.ts";
 export * as updates from "./updates.ts";
 export * as uploads from "./uploads.ts";
 export * as users from "./users.ts";
+export * from './types.ts';
+

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -25,3 +25,4 @@ export * from "./request_iter.ts";
 export * from "./entity_cache.ts";
 export * from "./entity_cache.ts";
 export * from "./version.ts";
+export * from './classes.ts';


### PR DESCRIPTION
These were exported previously, but forgotten to reexport after the circular imports thing.